### PR TITLE
fix: replaced trivia to interview question

### DIFF
--- a/content/batch/learn/css/flex.mdx
+++ b/content/batch/learn/css/flex.mdx
@@ -33,7 +33,7 @@ Want to improve this page?. Raise a issue on [@github](https://github.com/Manish
 <TabsList>
   <TabsTrigger value="learn">Learn</TabsTrigger>
   <TabsTrigger value="assignment">Assignment</TabsTrigger>
-  <TabsTrigger value="trivia">Trivia</TabsTrigger>
+  <TabsTrigger value="interview">Interview Questions</TabsTrigger>
   <TabsTrigger value="playground">Playground</TabsTrigger>
 
 </TabsList>
@@ -200,8 +200,8 @@ Want to improve this page?. Raise a issue on [@github](https://github.com/Manish
 
 </TabsContent>
 
-<TabsContent value="trivia">
-    Trivia Questions on css flex
+<TabsContent value="interview">
+    Interview Questions on css flex
 </TabsContent>
 
 <TabsContent value="playground">

--- a/content/batch/learn/html/basic.mdx
+++ b/content/batch/learn/html/basic.mdx
@@ -20,7 +20,7 @@ Want to improve this page?. Raise a issue on [@github](https://github.com/Manish
 <TabsList>
   <TabsTrigger value="learn">Learn</TabsTrigger>
   <TabsTrigger value="assignment">Assignment</TabsTrigger>
-  <TabsTrigger value="trivia">Trivia</TabsTrigger>
+  <TabsTrigger value="interview">Interview Questions</TabsTrigger>
   <TabsTrigger value="playground">Playground</TabsTrigger>
 
 </TabsList>
@@ -295,8 +295,8 @@ Want to improve this page?. Raise a issue on [@github](https://github.com/Manish
 
 </TabsContent>
 
-<TabsContent value="trivia">
-    Trivia Questions on css flex
+<TabsContent value="interview">
+    Interview Questions on css flex
 </TabsContent>
 
 <TabsContent value="playground">


### PR DESCRIPTION
Fixes #49 
Closes #49 

## Fixes
- this PR replaced the "trivia" name to "Interview Question" in [DOCS] to add interview Question in the future.


## Screenshot

![Screenshot 2023-10-01 145531](https://github.com/FrontendFreaks/Official-Website/assets/122002784/ab93b63e-e8aa-40c9-8fed-65bf38ed7f98)
