### PR TITLE
Fix for GitHub icon should link to GitHub repo not live website #52

### DIFF
--- a/app/(batches)/layout.tsx
+++ b/app/(batches)/layout.tsx
@@ -24,7 +24,7 @@ const CourseRootLayout = ({ children }: BatchRootLayoutProps) => {
               <div className=" px-3 hidden md:flex">
                 <CommandMenu />
               </div>
-              <Link href="/" target="_blank" rel="noreferrer">
+              <Link href="https://github.com/FrontendFreaks" target="_blank" rel="noreferrer">
                 <Icons.gitHub className="h-7 w-7" />
                 <span className="sr-only">GitHub</span>
               </Link>

--- a/app/(docs)/layout.tsx
+++ b/app/(docs)/layout.tsx
@@ -24,7 +24,7 @@ const CourseRootLayout = ({ children }: BatchRootLayoutProps) => {
               <div className=" px-3 hidden md:flex">
                 <CommandMenu />
               </div>
-              <Link href="/" target="_blank" rel="noreferrer">
+              <Link href="https://github.com/FrontendFreaks" target="_blank" rel="noreferrer">
                 <Icons.gitHub className="h-7 w-7" />
                 <span className="sr-only">GitHub</span>
               </Link>


### PR DESCRIPTION
Issue : GitHub icon should link to GitHub repo not live website #52 

Fix : Update the github icon hyperlink to point to frontend freaks github repo.

