### PR TITLE
Fix 'MainNav' and 'MobileNav' for consistent navigation

### DIFF
--- a/components/layout/main-nav.tsx
+++ b/components/layout/main-nav.tsx
@@ -48,8 +48,8 @@ export default function MainNav({ items, children }: MainNavProps) {
         className="flex items-center space-x-2 md:hidden"
         onClick={() => setShowMobileMenu(!showMobileMenu)}
       >
-        {showMobileMenu ? <Icons.close /> : <Icons.logo />}
-        <span className="font-bold">Menu</span>
+        {/* {showMobileMenu ? <Icons.close /> : <Icons.logo />} */}
+        <span className="font-bold">Frontend Freaks</span>
       </button>
       {showMobileMenu && items && (
         <MobileNav items={items}>{children}</MobileNav>

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -19,7 +19,7 @@ export function MobileNav({ items, children }: MobileNavProps) {
       <div className="relative z-20 grid gap-6 rounded-md bg-popover p-4 text-popover-foreground shadow-md">
         <Link href="/" className="flex items-center space-x-2">
           <Icons.logo />
-          <span className="font-bold">Frontend</span>
+          <span className="font-bold">Menu</span>
         </Link>
         <nav className="grid grid-flow-row auto-rows-max text-sm">
           {items.map((item, index) => (


### PR DESCRIPTION
## **EXISTING ISSUES:** 

It's important to note that the navigation bar in the project has a issue:

- The problem is that the main navigation bar content displays ```Frontend Freaks``` in the desktop view but shows ```Menu``` in mobile view.
- This inconsistency could lead to confusion or uncertainty for users about the exact brand name when navigating the website.

For example, the below is displayed in desktop.

![Image-1](https://github.com/FrontendFreaks/Official-Website/assets/127607339/32b55159-3127-4216-aed9-118f925c416a)

But, in mobile view it looks like this.

![Image-2](https://github.com/FrontendFreaks/Official-Website/assets/127607339/3df01fd8-d09c-49d9-a27e-7a768b1022ab)

And, if we click on ```Menu```, then the toggle menu in mobile view shows:

![Image-3](https://github.com/FrontendFreaks/Official-Website/assets/127607339/24945509-bee3-4289-b145-fb4b00f56595)

## CHANGES MADE:

To address this issue, I have made the following changes:

- I have updated the ```MainNav``` component to display **Frontend Freaks** as the main navigation bar content in both desktop and mobile views.
- I have also updated the ```MobileNav``` component to display **Frontend Freaks** as the main content in mobile view, maintaining consistency with the desktop view.
- I have improved brand clarity by ensuring that the name ```Frontend Freaks``` is consistently displayed in both navigation bars, leaving no ambiguity. 

Here's how the fixed navigation bar will look:

1. In desktop view,

![Image-4](https://github.com/FrontendFreaks/Official-Website/assets/127607339/32b55159-3127-4216-aed9-118f925c416a)

2. In mobile view,

![Image-5](https://github.com/FrontendFreaks/Official-Website/assets/127607339/b7a64b73-8984-487c-a910-a6edd92ea67a)

And, if we click on ```Frontend Freaks```, then the toggle menu in mobile view shows:

![Image-6](https://github.com/FrontendFreaks/Official-Website/assets/127607339/e7f77d0f-4567-4937-a893-fe24000e2268)

## REQUEST:

Please review and merge this pull request at your earliest convenience. I have attached the screenshots for existing and updated navigation as well. Thank you for your attention to this enhancement, which addresses the issue of inconsistent navigation between desktop and mobile views in our website. I look forward to your suggestions and edits.