### PR TITLE
docs link not appearing in navbar issue fixed

### DIFF
--- a/config/sidebar.ts
+++ b/config/sidebar.ts
@@ -214,5 +214,9 @@ export const docsConfig: DocsConfig = {
       title: "Hire",
       href:  "/batch/hire/hire",
     },
+    {
+      title: "Docs",
+      href: "https://frontendfreaks.vercel.app/docs",
+    },
   ],
 };


### PR DESCRIPTION
[Feat] Link docs #88

issue fixed just added new array element in "mainNav" array in sidebar.ts , after making this change docs link is now appearing in navbar
