### PR TITLE
remove next-font warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend-freaks-website",
       "version": "0.1.0",
       "dependencies": {
-        "@next/font": "^13.4.7",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-dialog": "^1.0.4",
         "@radix-ui/react-dropdown-menu": "^2.0.5",
@@ -871,11 +870,6 @@
       "dependencies": {
         "glob": "7.1.7"
       }
-    },
-    "node_modules/@next/font": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.4.7.tgz",
-      "integrity": "sha512-l28ifb3pjKznQeXmiCD5VXkmqdpMrcUQMr4ZChAgTKrjckl/aGyRLOIlL/ABhTHmzMujdt/TTWUsdABArNK5gA=="
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "13.4.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@next/font": "^13.4.7",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.5",


### PR DESCRIPTION
## Fixes Issue

Fixed #106 

## Changes proposed

<!-- List all the proposed changes in your PR -->

- [✅ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ✅] All new and existing tests passed.
- [✅ ] This PR does not contain plagiarized content.
- [ ✅] The title of my pull request is a short description of the requested changes.

## Screenshots

<img width="701" alt="Screenshot 2023-10-02 at 10 28 55 PM" src="https://github.com/FrontendFreaks/Official-Website/assets/70282139/cece6746-46b5-4756-aa04-14a2f93125d3">

## Note to reviewers

I have removed the warning described in the issue:
`warn Your project has '@next/font' installed as a dependency, please use the built-in 'next/font' instead. The '@next/font' package will be removed in Next.js 14.`
