### PR TITLE
fix: Added missing global toggle with responsiveness

### DIFF
--- a/app/(batches)/layout.tsx
+++ b/app/(batches)/layout.tsx
@@ -2,9 +2,11 @@ import { CommandMenu } from "@/components/command-menu";
 import { Icons } from "@/components/icons";
 import MainNav from "@/components/layout/main-nav";
 import { DocsSidebarNav } from "@/components/layout/sidebar-nav";
+import { ModeToggle } from "@/components/mode-toggle";
 import { navConfig } from "@/config/nav";
 import { docsConfig } from "@/config/sidebar";
 import Link from "next/link";
+
 
 interface BatchRootLayoutProps {
   children: React.ReactNode;
@@ -24,6 +26,7 @@ const CourseRootLayout = ({ children }: BatchRootLayoutProps) => {
               <div className=" px-3 hidden md:flex">
                 <CommandMenu />
               </div>
+             <ModeToggle/>
               <Link href="https://github.com/FrontendFreaks" target="_blank" rel="noreferrer">
                 <Icons.gitHub className="h-7 w-7" />
                 <span className="sr-only">GitHub</span>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Found missing modetoggle in other pages so i added them globally with responsiveness.

## Screenshots(before and after)
![Screenshot (567)](https://github.com/FrontendFreaks/Official-Website/assets/91207994/0366988f-50c6-4d5f-b102-437455c0e3ef)
![Screenshot (568)](https://github.com/FrontendFreaks/Official-Website/assets/91207994/e3f944b0-9537-497c-aded-aeec87ea3a57)
![Screenshot (569)](https://github.com/FrontendFreaks/Official-Website/assets/91207994/05c8a68f-76e2-432d-a005-8f7ffa6e7024)
![Screenshot (570)](https://github.com/FrontendFreaks/Official-Website/assets/91207994/9d4fbca1-09d1-409a-9371-637e7030dbb4)
![Screenshot (571)](https://github.com/FrontendFreaks/Official-Website/assets/91207994/cc4a5e05-5c1b-482d-8e0f-b0ed57ee4bf6)


<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
I was the one how raised this issue yesterday so please review and merge my pr
