### PR TITLE
fix: Added missing modetoggle in doc page

### DIFF
--- a/app/(docs)/layout.tsx
+++ b/app/(docs)/layout.tsx
@@ -2,6 +2,7 @@ import { CommandMenu } from "@/components/command-menu";
 import { Icons } from "@/components/icons";
 import { DocSideNav } from "@/components/layout/docs-nav";
 import MainNav from "@/components/layout/main-nav";
+import { ModeToggle } from "@/components/mode-toggle";
 import { DocumentationConfig } from "@/config/docs";
 import { docsConfig } from "@/config/sidebar";
 import Link from "next/link";
@@ -24,6 +25,7 @@ const CourseRootLayout = ({ children }: BatchRootLayoutProps) => {
               <div className=" px-3 hidden md:flex">
                 <CommandMenu />
               </div>
+              <ModeToggle/>
               <Link href="https://github.com/FrontendFreaks" target="_blank" rel="noreferrer">
                 <Icons.gitHub className="h-7 w-7" />
                 <span className="sr-only">GitHub</span>


### PR DESCRIPTION

## Fixes Issue
 Added missing modetoggle in doc page which was missing due to hardcoded live link.

## Screenshots(before and after in doc page)
![Screenshot (575)](https://github.com/FrontendFreaks/Official-Website/assets/91207994/1233e7fb-0b21-4263-9984-33121177d6b4)
![Screenshot (576)](https://github.com/FrontendFreaks/Official-Website/assets/91207994/716bad2c-24cf-41b9-b0f1-3bb282351ffd)

