### PR TITLE
Fix: Added Missing key prop

### DIFF
--- a/components/layout/sidebar-nav.tsx
+++ b/components/layout/sidebar-nav.tsx
@@ -33,8 +33,8 @@ export function DocsSidebarNav({ items }: DocsSidebarNavProps) {
               <AccordionContent>
                 {item.items ? (
                   <div className="dark:text-gray-400">
-                    {item.items.map(item => (
-                      <>
+                    {item.items.map((item,index) => (
+                      <div key={index}>
                         {item.href ? (
                           <DocsSidebarNavItem item={item} pathname={pathname} />
                         ) : (
@@ -58,7 +58,7 @@ export function DocsSidebarNav({ items }: DocsSidebarNavProps) {
                             </AccordionItem>
                           </Accordion>
                         )}
-                      </>
+                      </div>
                     ))}
                   </div>
                 ) : null}

--- a/config/nav.ts
+++ b/config/nav.ts
@@ -15,6 +15,6 @@ export const navConfig: NavItem[] = [
   },
   {
     title: "Docs",
-    href: "https://frontendfreaks.vercel.app/docs",
+    href: "/docs",
   },
 ];


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
`Closes #133 `

## Fixes Issue
 This pr sloves the key prop warning in the website caused by missing key.

## Screenshots(Before and After)
![Screenshot (577)](https://github.com/FrontendFreaks/Official-Website/assets/91207994/79d8e3e9-1776-4151-a941-5a97c5cebcd7)

![Screenshot (578)](https://github.com/FrontendFreaks/Official-Website/assets/91207994/c1466377-2f3d-47c5-8902-054a2f4dfb78)



