### PR TITLE
Aligned the card buttons to bottom in homepage

### DIFF
--- a/components/tracks.tsx
+++ b/components/tracks.tsx
@@ -13,6 +13,7 @@ export default function Tracks({}: Props) {
       </h4>
       <p>Master the Frontend Development with Frontend Freaks</p>
 
+      {/* Cards Wrapper */}
       <div className="flex gap-6 mt-8 md:flex-row flex-col">
         <div className="flex flex-col gap-3 items-center border p-4 rounded-lg">
           <Image
@@ -22,7 +23,7 @@ export default function Tracks({}: Props) {
             height={250}
             className="rounded bg-white"
           />
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 flex-grow">
             <h3 className="text-xl font-bold ">Build Your Foundation</h3>
             <p className="text-md text-slate-600 max-w-md dark:text-white">
               Make your foundation strong by learning HTML, CSS, JS, Git, and
@@ -45,7 +46,7 @@ export default function Tracks({}: Props) {
             height={250}
             className="rounded bg-white"
           />
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 flex-grow">
             <h3 className="text-xl font-bold ">DSA In Javascript</h3>
             <p className="text-md text-slate-600 max-w-md dark:text-white">
               Enroll for this batch to ace DSA skills with javascript, enhancing
@@ -67,7 +68,7 @@ export default function Tracks({}: Props) {
             height={250}
             className="rounded bg-white"
           />
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 flex-grow">
             <h3 className="text-xl font-bold ">Build Projects</h3>
             <p className="text-md text-slate-600 max-w-md dark:text-white">
               Build the project with the latest technologies like React, Redux,
@@ -89,7 +90,7 @@ export default function Tracks({}: Props) {
             height={250}
             className="rounded bg-white"
           />
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 flex-grow">
             <h3 className="text-xl font-bold ">Get Hired</h3>
             <p className="text-md text-slate-600 max-w-md dark:text-white">
               Enroll for this batch to ace interviews with tips, tricks, and


### PR DESCRIPTION
## Fixes Issue
Closes #171

## Description 
On the homepage, in the OUR BATCHES section, the `JOIN` button is not aligned properly. In this PR, this issue is solved and now the buttons are aligned to the bottom of the card irrespective of the length of text of the cards.

## Changes proposed
[x] - Added a CSS class `flex-grow` inside each card. So that the text can take the available empty space. And button align to bottom

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

BEFORE: 
![image](https://github.com/FrontendFreaks/Official-Website/assets/43143907/f992772b-dcc4-4d20-8d53-1dc207aaf33e)

AFTER
![image](https://github.com/FrontendFreaks/Official-Website/assets/43143907/a62d2af7-b51d-4106-8ca0-05a37d835b9f)


## Note to reviewers

<!-- Add notes to reviewers if applicable -->
