### PR TITLE
Hidden text Is Visible in the DOCS section

### DIFF
--- a/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/app/(docs)/docs/[[...slug]]/page.tsx
@@ -36,7 +36,7 @@ export default async function page({ params }: Props) {
       </div>
       <div className="hidden text-sm xl:block">
         <div className="sticky top-16 -mt-10 max-h-[calc(var(--vh)-4rem)] overflow-y-auto pt-10">
-          table of contents
+       
         </div>
       </div>
     </main>


### PR DESCRIPTION


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![image](https://github.com/FrontendFreaks/Official-Website/assets/124510117/2d6047f0-396d-4d60-b3b6-531800ca08db)

> Here There is text table of contents is visible is visible only in Docs Section but its not used anywhere in Learn ,Hire ,Build


![image](https://github.com/FrontendFreaks/Official-Website/assets/124510117/06542a1b-b105-417d-ab78-a05dd677d472)

> This Text located in the Hidden class 
>So after deleting it it will look like this
![image](https://github.com/FrontendFreaks/Official-Website/assets/124510117/79920b2c-5147-4853-99df-1dada8863d94)
## Note to reviewers


