### PR TITLE
Button/link consistency

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -37,10 +37,10 @@ export default function Home() {
               target="_blank"
               className={cn(buttonVariants({ variant: "outline" }))}
             >
-              Join Community
+              Join Discord Community
             </Link>
             <Link href="/batch" className={cn(buttonVariants())}>
-              Join Mentorship
+              Get Started
             </Link>
           </div>
         </div>

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -35,11 +35,11 @@ export default function Home() {
             <Link
               href="https://discord.com/invite/vee94km4Wh"
               target="_blank"
-              className={cn(buttonVariants({ variant: "outline" }))}
+              className={cn(buttonVariants({ variant: "outlineRounded" }))}
             >
-              Join Discord Community
+              Join Community
             </Link>
-            <Link href="/batch" className={cn(buttonVariants())}>
+            <Link href="/batch" className={cn(buttonVariants({ variant: "rounded" }))}>
               Get Started
             </Link>
           </div>

--- a/components/layout/main-nav.tsx
+++ b/components/layout/main-nav.tsx
@@ -52,6 +52,7 @@ export default function MainNav({ items, children }: MainNavProps) {
           </nav>
         </div>
       ) : null}
+      
       <button
         className="flex items-center space-x-2 md:hidden"
         onClick={() => setShowMobileMenu(!showMobileMenu)}

--- a/components/layout/site-footer.tsx
+++ b/components/layout/site-footer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { cn } from "@/lib/utils";
-import { Button } from "../ui/button";
+import { Button, buttonVariants } from "../ui/button";
+import Link from "next/link";
 
 type Props = {};
 
@@ -25,9 +26,13 @@ export default function SiteFooter({}: Props) {
           >
             Learn
           </a>
-          <a href="https://discord.com/invite/vee94km4Wh" target="_blank">
-            <Button className="rounded-full">Join Community</Button>
-          </a>
+          <Link
+              href="https://discord.com/invite/vee94km4Wh"
+              target="_blank"
+              className={`${cn(buttonVariants()) } hidden w-0 md:flex md:min-w-fit`}
+            >
+              Join Discord Community
+            </Link>
           <a
             href="/batch/build/react/fundamentals"
             className={cn(

--- a/components/layout/site-footer.tsx
+++ b/components/layout/site-footer.tsx
@@ -29,7 +29,7 @@ export default function SiteFooter({}: Props) {
           <Link
               href="https://discord.com/invite/vee94km4Wh"
               target="_blank"
-              className={`${cn(buttonVariants()) } hidden w-0 md:flex md:min-w-fit`}
+              className={`${cn(buttonVariants()) } md:flex md:min-w-fit`}
             >
               Join Discord Community
             </Link>

--- a/components/layout/site-footer.tsx
+++ b/components/layout/site-footer.tsx
@@ -29,9 +29,9 @@ export default function SiteFooter({}: Props) {
           <Link
               href="https://discord.com/invite/vee94km4Wh"
               target="_blank"
-              className={`${cn(buttonVariants()) } md:flex md:min-w-fit`}
+              className={`${cn(buttonVariants({ variant: "rounded" })) } md:flex md:min-w-fit`}
             >
-              Join Discord Community
+              Join Community
             </Link>
           <a
             href="/batch/build/react/fundamentals"

--- a/components/layout/site-header.tsx
+++ b/components/layout/site-header.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import MainNav from "./main-nav";
 import { navConfig } from "@/config/nav";
-import { Button } from "../ui/button";
+import { Button, buttonVariants } from "../ui/button";
 import { ModeToggle } from "../mode-toggle";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 type Props = {};
 
@@ -12,11 +14,19 @@ export default function SiteHeader({}: Props) {
       <div className="container flex h-14 items-center md:gap-6 gap-9 md:px-8 px-0">
         <MainNav items={navConfig} />
         <ModeToggle />
-        <a href="https://discord.com/invite/vee94km4Wh" target="_blank">
-          <Button className="hidden md:inline-block rounded-full">
-            Mentorship
+        {/* <a href="https://discord.com/invite/vee94km4Wh" target="_blank">
+          <Button className="hidden md:flex md:min-w-fit rounded-full">
+          Join Discord Community
           </Button>
-        </a>
+          
+        </a> */}
+         <Link
+              href="https://discord.com/invite/vee94km4Wh"
+              target="_blank"
+              className={`${cn(buttonVariants()) } hidden w-0 md:flex md:min-w-fit`}
+            >
+              Join Discord Community
+            </Link>
       </div>
     </header>
   );

--- a/components/layout/site-header.tsx
+++ b/components/layout/site-header.tsx
@@ -14,18 +14,13 @@ export default function SiteHeader({}: Props) {
       <div className="container flex h-14 items-center md:gap-6 gap-9 md:px-8 px-0">
         <MainNav items={navConfig} />
         <ModeToggle />
-        {/* <a href="https://discord.com/invite/vee94km4Wh" target="_blank">
-          <Button className="hidden md:flex md:min-w-fit rounded-full">
-          Join Discord Community
-          </Button>
-          
-        </a> */}
+        
          <Link
               href="https://discord.com/invite/vee94km4Wh"
               target="_blank"
-              className={`${cn(buttonVariants()) } hidden w-0 md:flex md:min-w-fit`}
+              className={`${cn(buttonVariants({ variant: "rounded" })) } hidden w-0 md:flex md:min-w-fit`}
             >
-              Join Discord Community
+              Join Community
             </Link>
       </div>
     </header>

--- a/components/tracks.tsx
+++ b/components/tracks.tsx
@@ -33,7 +33,7 @@ export default function Tracks({}: Props) {
           </div>
           <Link
             href="/batch/learn/html/basic"
-            className={cn(buttonVariants(), "px-8 py-2 mt-4")}
+            className={cn(buttonVariants({ variant: "rounded" }), "px-8 py-2 mt-4")}
           >
             Join
           </Link>
@@ -55,7 +55,7 @@ export default function Tracks({}: Props) {
           </div>
           <Link
             href="/batch/dsa/loops"
-            className={cn(buttonVariants(), "px-8 py-2 mt-4")}
+            className={cn(buttonVariants({ variant: "rounded" }), "px-8 py-2 mt-4")}
           >
             Join
           </Link>
@@ -77,7 +77,7 @@ export default function Tracks({}: Props) {
           </div>
           <Link
             href="/batch/build/react/fundamentals"
-            className={cn(buttonVariants(), "px-8 py-2 mt-4")}
+            className={cn(buttonVariants({ variant: "rounded" }), "px-8 py-2 mt-4")}
           >
             Join
           </Link>
@@ -99,7 +99,7 @@ export default function Tracks({}: Props) {
           </div>
           <Link
             href="/batch/hire/hire"
-            className={cn(buttonVariants(), "px-8 py-2 mt-4")}
+            className={cn(buttonVariants({ variant: "rounded" }), "px-8 py-2 mt-4")}
           >
             Join
           </Link>

--- a/components/tracks.tsx
+++ b/components/tracks.tsx
@@ -33,7 +33,7 @@ export default function Tracks({}: Props) {
           </div>
           <Link
             href="/batch/learn/html/basic"
-            className={cn(buttonVariants(), "rounded-full px-8 py-2 mt-4")}
+            className={cn(buttonVariants(), "px-8 py-2 mt-4")}
           >
             Join
           </Link>
@@ -55,7 +55,7 @@ export default function Tracks({}: Props) {
           </div>
           <Link
             href="/batch/dsa/loops"
-            className={cn(buttonVariants(), "rounded-full px-8 py-2 mt-4")}
+            className={cn(buttonVariants(), "px-8 py-2 mt-4")}
           >
             Join
           </Link>
@@ -77,7 +77,7 @@ export default function Tracks({}: Props) {
           </div>
           <Link
             href="/batch/build/react/fundamentals"
-            className={cn(buttonVariants(), "rounded-full px-8 py-2 mt-4")}
+            className={cn(buttonVariants(), "px-8 py-2 mt-4")}
           >
             Join
           </Link>
@@ -99,7 +99,7 @@ export default function Tracks({}: Props) {
           </div>
           <Link
             href="/batch/hire/hire"
-            className={cn(buttonVariants(), "rounded-full px-8 py-2 mt-4")}
+            className={cn(buttonVariants(), "px-8 py-2 mt-4")}
           >
             Join
           </Link>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -12,8 +12,11 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+         rounded: "bg-primary text-primary-foreground hover:bg-primary/90 rounded-full",
         outline:
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          outlineRounded:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground rounded-full",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",


### PR DESCRIPTION


## Fixes Issue
Resolved #222 



## Changes proposed

<!-- List all the proposed changes in your PR -->

There is no consistency in the styling and naming of buttons. Somewhere the buttons/links are rounded and somewhere it is squared. In the header, the Mentorship button has the link to Discord but it should be Join Community.

Rename Join Community to Join Discord Community, to specify and give a hit of what the community is like.

(Changes in Header, Footer, and other sections)


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots



https://github.com/FrontendFreaks/Official-Website/assets/65448358/540e546d-b2b9-4345-b45e-6f48a9ab884e



## Note to reviewers

<!-- Add notes to reviewers if applicable -->
