### PR TITLE
Fixed #205 - feat: added resume templates links for reference under the Hire Batch Tab

### DIFF
--- a/content/batch/hire/hire.mdx
+++ b/content/batch/hire/hire.mdx
@@ -48,3 +48,25 @@ Create a resume on Overleaf 🖥️ to showcase your skills and experience in a 
 
 💰 How to negotiate offers: Once you receive an offer, learn how to negotiate the terms and conditions to get the best deal possible.
 
+<div class="mt-5">
+     <hr/>
+</div>
+
+### 📃 Below are some latex resume templates that you can use to create your resume:
+
+     <div>
+          #### One Column Resume Templates
+               1. <a class="underline" href="https://www.overleaf.com/latex/templates/jakes-resume-anonymous/cstpnrbkhndn" target="_blank">One Column Resume Template - 1</a>
+               2. <a class="underline" href="https://www.overleaf.com/latex/templates/entry-level-resume-template/xzswwssvhvqr" target="_blank">One Column Resume Template - 2</a>
+               3. <a class="underline" href="https://www.overleaf.com/latex/templates/faangpath-simple-template/npsfpdqnxmbc" target="_blank">One Column Resume Template - 3</a>
+               4. <a class="underline" href="https://www.overleaf.com/latex/templates/software-engineer-resume/gqxmqsvsbdjf" target="_blank">One Column Resume Template - 4</a>
+               5. <a class="underline" href="https://www.overleaf.com/latex/templates/70-plus-ats-rating-resume-template/ssprfsctyddz" target="_blank">One Column Resume Template - 5</a>
+     </div>
+
+     <div>
+          #### Two Column Resume Templates
+               1. <a class="underline" href="https://www.overleaf.com/latex/templates/deedy-cv/bjryvfsjdyxz" target="_blank">Two Column Resume Template - 1</a>
+               2. <a class="underline" href="https://www.overleaf.com/articles/pratiksha-jains-cv/tvfhswmxphwd" target="_blank">Two Column Resume Template - 2</a>
+               3. <a class="underline" href="https://www.overleaf.com/latex/templates/magicalcv/ybfgdrchrrxj" target="_blank">Two Column Resume Template - 3</a>
+               4. <a class="underline" href="https://www.overleaf.com/articles/anurags-resume/jdfqhmhqzbxv" target="_blank">Two Column Resume Template - 4</a>
+     </div>


### PR DESCRIPTION
## Fixes Issue #205 

## Description
- Added 9 overleaf latex resume templates link (5 - 1 col, 4 - 2 col)

## Screenshots
![image](https://github.com/FrontendFreaks/Official-Website/assets/112842857/2235dba4-4aaf-4ba1-bc06-2a14b5199054)

